### PR TITLE
[BESP_03_이승헌/완료]

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+simpleDB

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleHome" value="" />
+        <option name="gradleJvm" value="graalvm-ce-23" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,7 +4,7 @@
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_X" default="true" project-jdk-name="openjdk-23" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" project-jdk-name="openjdk-23" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/src/main/java/com/ll/SimpleDb/SimpleDb.java
+++ b/src/main/java/com/ll/SimpleDb/SimpleDb.java
@@ -2,10 +2,141 @@ package com.ll.SimpleDb;
 
 import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
 public class SimpleDb {
-    private final String host;
+    private final ThreadLocal<Connection> connection;
+    //Connection connection;
+    private  boolean isDev;
+    private final String url;
     private final String username;
     private final String password;
     private final String dbName;
+
+
+    //후에는 타임존과 같은 파라미터도 입력 받도록..
+    //기존 코드: 여기서 생성자로 생성할 때 한 번만 스레드 로컬에 등록했다.
+    //참고 코드: 여기서 생성자로 생성할 때 말고도 스레드 로컬에 커넥션이 비어있거나 끊어져있으면 실행한다.
+    public SimpleDb(String url, String username, String password, String dbName) {
+        this.url=url;
+        this.username=username;
+        this.password=password;
+        this.dbName=dbName;
+
+        connection=new ThreadLocal<>();
+        //System.out.println("디비 생성자 호출됨");
+        getDBConnection();
+        isDev=false;
+
+    }
+
+    private Connection getDBConnection(){
+        String full_url="jdbc:mysql://"+url+":3306/"+dbName+"?serverTimezone=UTC";
+        try {
+
+            if(connection.get() == null || connection.get().isClosed()) {
+                //System.out.println("스레드 로컬에 커넥션 세팅");
+                //테스트 17을 돌려보면 여기가 11번 호출된다.
+                //메인 스레드는 생성자를 통해 여기로 접근한다.
+                //나머지 스레드도 어쨌든 SimpleDb를 통해서 genSql을 실행하게 된다.
+                Connection con = DriverManager.getConnection(full_url, username, password);
+                connection.set(con);
+            }
+
+            return connection.get();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+
+//    public void setConnection(){
+//        this.connection.set(generateConnection());
+//    }
+//
+//    public Connection getConnection(){
+//        return this.connection.get();
+//    }
+//
+//    public void removeConnection(){
+//        this.connection.remove();
+//    }
+
+    public void setDevMode(boolean b) {
+        isDev=b;
+    }
+
+    public void run(String query,Object... args) {
+        if(query==null || query.isBlank()) return;
+
+        query=query.trim();
+
+        try(PreparedStatement prepstmt=getDBConnection().prepareStatement(query)) {
+
+            if(args.length==0){
+                prepstmt.executeUpdate();
+
+            }else{
+
+                for(int i=1;i<=args.length;i++){
+                    prepstmt.setObject(i,args[i-1]);
+                }
+
+                prepstmt.executeUpdate();
+            }
+
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    //스레드 로컬에 있는 연결을 그대로 주므로, Sql 객체의 커넥션과 SimpleDb 커넥션은 같다.
+    public Sql genSql() {
+        //System.out.println("sql을 위한 커넥션을 생성");
+        return new Sql(getDBConnection());
+    }
+
+    public void startTransaction() {
+        try {
+            getDBConnection().setAutoCommit(false);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void rollback() {
+        try {
+            getDBConnection().rollback();
+            getDBConnection().setAutoCommit(true);
+        }catch (SQLException e){
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void commit() {
+        try {
+            getDBConnection().commit();
+            getDBConnection().setAutoCommit(true);
+        }catch (SQLException e){
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void close() {
+        if(connection.get()!=null) {
+            //System.out.println("클로징 호출됨");
+            try {
+                connection.get().close();
+            } catch (SQLException e) {
+                throw new RuntimeException(e);
+            }finally {
+                connection.remove();
+            }
+        }
+    }
+
+
 }

--- a/src/main/java/com/ll/SimpleDb/Sql.java
+++ b/src/main/java/com/ll/SimpleDb/Sql.java
@@ -1,0 +1,380 @@
+package com.ll.SimpleDb;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.sql.*;
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class Sql {
+    private final Connection connection;
+    //private ThreadLocal<Connection> connection;
+
+    //private final SimpleDb db;
+    String finalQuery="";
+
+    static final String[] INJECTIONS={"=","--",";","DROP","drop","alter","ALTER","TABLE","table","OR","or","union","UNION","AND","and","'"};
+    public Sql(Connection connection){
+        this.connection=connection;
+        //this.connection=new ThreadLocal<>();
+        //this.connection.set(connection);
+    }
+
+//    public Connection getConnection(){
+//        return connection;
+//    }
+
+    //개선할 수 있는 점: Sql 한 쿼리만 날린 후 다시 쓰이는 경우가 없으므로, 파라미터를 담을 수 있는 리스트를 필드로 만들어 거기에 파라미터를 넣고 나중에 setObject로 하나씩 넣는다.
+    public Sql append(String query, Object... args) {
+        //인젝션을 막아라!
+
+        //System.out.println("어펜딩 하는 중");
+
+        if(args.length==0){
+            finalQuery+=query+" ";
+        }else{
+            for(String exploit : INJECTIONS){
+                for (Object arg : args) {
+                    if (arg.toString().contains(exploit)) {
+                        return this; //아 몰라 넌 바인딩 안할거야.
+                    }
+                }
+            }
+
+            for(Object arg:args) {
+                int idx=query.indexOf('?');
+                query=query.substring(0,idx)+addPrefixPostfix(arg.toString())+query.substring(idx+1);
+            }
+            finalQuery+=query+" ";
+        }
+
+        return this;
+    }
+
+    private String addPrefixPostfix(String arg){
+        return "'"+arg+"'";
+    }
+
+    public Sql appendIn(String query, Object... args) {
+        if(args.length==0){
+            finalQuery+=query+" ";
+        }else{
+            for(String exploit : INJECTIONS){
+                for(int i=0;i<args.length;i++){
+                    if(args[0].toString().contains(exploit)) {
+                        return this; //아 몰라 넌 바인딩 안할거야.
+                    }
+                }
+            }
+            String params = Arrays.stream(args).map(object -> addPrefixPostfix(object.toString()))
+                    .collect(Collectors.joining(","));
+            finalQuery+=query.replace("?",params)+" ";
+        }
+        return this;
+    }
+
+    public long insert() {
+        //db.setConnection();
+
+        //try(Connection connection= this.connection){
+        try(PreparedStatement prepstmt=connection.prepareStatement(finalQuery, Statement.RETURN_GENERATED_KEYS);) {
+            int affectedRows = prepstmt.executeUpdate();
+
+            if (affectedRows > 0) {
+                try (ResultSet generatedKeys = prepstmt.getGeneratedKeys()) {
+                    if (generatedKeys.next()) {
+                        return generatedKeys.getLong(1); // 첫 번째 열의 값
+                    }
+                }
+            }
+            //}
+
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }finally {
+            finalQuery="";
+            //db.removeConnection();
+        }
+
+        return 0;
+    }
+
+    public long selectLong() {
+        //db.setConnection();
+        long value=0;
+        //try(Connection connection=this.connection){
+        try(PreparedStatement prepstmt=connection.prepareStatement(finalQuery)) {
+            try (ResultSet rs = prepstmt.executeQuery()) {
+                if (rs.next()) return rs.getInt(1);
+            }
+            //}
+        }catch (SQLException e){
+            throw new RuntimeException(e);
+        }finally {
+            //db.removeConnection();
+            finalQuery="";
+        }
+
+        return value;
+    }
+
+    //리플렉션에 대해 좀 더 공부할 것
+    public <T> T selectRow(Class<T> _class) {
+        //System.out.println("셀렉트 로우 호출됨");
+
+        T instance = null;
+
+        //db.setConnection();
+
+        //try(Connection connection=this.connection){
+        try (PreparedStatement prepstmt = connection.prepareStatement(finalQuery)) {
+            try (ResultSet resultSet = prepstmt.executeQuery()) {
+                ResultSetMetaData metaData = resultSet.getMetaData();
+                int columnCount = metaData.getColumnCount();
+
+                Field[] fields = _class.getDeclaredFields();
+                instance = _class.getDeclaredConstructor().newInstance();
+                if (resultSet.next()) {
+                    for (int i = 1; i <= columnCount; i++) {
+                        String fieldName = metaData.getColumnName(i);
+                        Object fieldValue = resultSet.getObject(i);
+                        for (Field field : fields) {
+                            field.setAccessible(true);
+
+                            if (field.getName().equals(fieldName)) {
+                                field.set(instance, fieldValue);
+                            }
+                        }
+                    }
+                }
+                //  }
+
+            } catch (InvocationTargetException | InstantiationException | IllegalAccessException |
+                     NoSuchMethodException e) {
+                throw new RuntimeException(e);
+            }
+        }catch (SQLException sqlException) {
+            throw new RuntimeException(sqlException);
+        }finally {
+            //  db.removeConnection();
+            finalQuery="";
+        }
+        return instance;
+    }
+
+    public Map<String, Object> selectRow() {
+        //db.setConnection();
+        //try(Connection connection=this.connection){
+        try(PreparedStatement prepstmt=connection.prepareStatement(finalQuery)) {
+            try (ResultSet resultSet = prepstmt.executeQuery()) {
+                ResultSetMetaData metaData = resultSet.getMetaData();
+                int columnCount = metaData.getColumnCount();
+
+                if (resultSet.next()) {
+                    Map<String, Object> columnValueMap = new HashMap<>();
+                    for (int i = 1; i <= columnCount; i++) {
+                        columnValueMap.put(metaData.getColumnName(i), resultSet.getObject(i));
+                    }
+                    return columnValueMap;
+                }
+            }
+            //}
+        }catch (SQLException e){
+            throw new RuntimeException(e);
+        }finally {
+            //  db.removeConnection();
+            finalQuery="";
+        }
+
+        return null;
+    }
+
+    public LocalDateTime selectDatetime() {
+        //db.setConnection();
+
+        //try(Connection connection= this.connection){
+        try(PreparedStatement prepstmt=connection.prepareStatement(finalQuery)) {
+            try (ResultSet rs = prepstmt.executeQuery()) {
+                if (rs.next()) {
+                    // NOW()의 결과를 Timestamp 형식으로 가져오기
+                    java.sql.Timestamp currentTimestamp = rs.getTimestamp(1);
+
+                    // Timestamp를 LocalDateTime으로 변환
+                    return currentTimestamp.toLocalDateTime();
+
+                }
+            }
+            //}
+        }catch (SQLException e){
+            throw new RuntimeException(e);
+        }finally {
+            //db.removeConnection();
+            finalQuery="";
+        }
+
+        return null;
+    }
+
+    public String selectString() {
+        //db.setConnection();
+
+        String value="";
+        //try(Connection connection=this.connection){
+        try(PreparedStatement prepstmt=connection.prepareStatement(finalQuery)) {
+            try (ResultSet rs = prepstmt.executeQuery()) {
+                if (rs.next()) return rs.getString(1);
+            }
+            //}
+        }catch (SQLException e){
+            throw new RuntimeException(e);
+        }finally {
+            //db.removeConnection();
+            finalQuery="";
+        }
+
+        return value;
+    }
+
+    public Boolean selectBoolean() {
+        Boolean value=false;
+        //db.setConnection();
+
+        //try(Connection connection= this.connection){
+        try(PreparedStatement prepstmt=connection.prepareStatement(finalQuery)) {
+            try (ResultSet rs = prepstmt.executeQuery()) {
+                if (rs.next()) return rs.getBoolean(1);
+            }
+            //}
+        }catch (SQLException e){
+            throw new RuntimeException(e);
+        }finally {
+            //db.removeConnection();
+            finalQuery="";
+        }
+
+        return value;
+    }
+
+    public List<Long> selectLongs() {
+        List<Long> values=new ArrayList<>();
+        //db.setConnection();
+        //try(Connection connection= this.connection){
+        try(PreparedStatement prepstmt=connection.prepareStatement(finalQuery)) {
+            try (ResultSet rs = prepstmt.executeQuery()) {
+                while (rs.next()) {
+                    values.add(rs.getLong(1));
+                }
+            }
+            //}
+        }catch (SQLException e){
+            throw new RuntimeException(e);
+        }finally {
+            //db.removeConnection();
+            finalQuery="";
+        }
+
+        return values;
+    }
+
+    public <T> List<T> selectRows(Class<T> _class) {
+        List<T> instances=new ArrayList<>();
+        //db.setConnection();
+
+        //try(Connection connection=this.connection){
+        try (PreparedStatement prepstmt = connection.prepareStatement(finalQuery)) {
+            try (ResultSet resultSet = prepstmt.executeQuery()) {
+                ResultSetMetaData metaData = resultSet.getMetaData();
+                int columnCount = metaData.getColumnCount();
+
+                Field[] fields = _class.getDeclaredFields();
+
+                while (resultSet.next()) {
+                    T instance = _class.getDeclaredConstructor().newInstance();
+                    for (int i = 1; i <= columnCount; i++) {
+                        String fieldName = metaData.getColumnName(i);
+                        Object fieldValue = resultSet.getObject(i);
+                        for (Field field : fields) {
+                            field.setAccessible(true);
+
+                            if (field.getName().equals(fieldName)) {
+                                field.set(instance, fieldValue);
+                            }
+                        }
+                    }
+                    instances.add(instance);
+                }
+                //}
+
+            } catch (InvocationTargetException | NoSuchMethodException | IllegalAccessException |
+                     InstantiationException e) {
+                throw new RuntimeException(e);
+            }
+        }catch (SQLException sqlException) {
+            throw new RuntimeException(sqlException);
+        }finally {
+            //db.removeConnection();
+            finalQuery="";
+        }
+
+        return instances;
+    }
+
+    public int update() {
+        //db.setConnection();
+
+        //try(Connection connection= this.connection){
+        try(PreparedStatement prepstmt=connection.prepareStatement(finalQuery)) {
+            return prepstmt.executeUpdate();
+            //}
+        }catch (SQLException e){
+            throw new RuntimeException(e);
+        }finally {
+            //db.removeConnection();
+            finalQuery="";
+        }
+    }
+
+    public int delete() {
+        //db.setConnection();
+
+        //try(Connection connection= this.connection){
+        try(PreparedStatement prepstmt=connection.prepareStatement(finalQuery)) {
+            return prepstmt.executeUpdate();
+            //  }
+        }catch (SQLException e){
+            throw new RuntimeException(e);
+        }finally {
+            //db.removeConnection();
+            finalQuery="";
+        }
+    }
+
+    public List<Map<String, Object>> selectRows() {
+        //db.setConnection();
+
+        List<Map<String,Object>> result=new ArrayList<>();
+        //try(Connection connection=this.connection){
+        try(PreparedStatement prepstmt=connection.prepareStatement(finalQuery)) {
+            try (ResultSet resultSet = prepstmt.executeQuery()) {
+                ResultSetMetaData metaData = resultSet.getMetaData();
+                int columnCount = metaData.getColumnCount();
+
+                while (resultSet.next()) {
+                    Map<String, Object> columnValueMap = new HashMap<>();
+                    for (int i = 1; i <= columnCount; i++) {
+                        columnValueMap.put(metaData.getColumnName(i), resultSet.getObject(i));
+                    }
+                    result.add(columnValueMap);
+                }
+                return result;
+            }
+            //}
+        }catch (SQLException e){
+            throw new RuntimeException(e);
+        }finally {
+            //db.removeConnection();
+            finalQuery="";
+        }
+    }
+}

--- a/src/test/java/com/ll/simpleDb/Article.java
+++ b/src/test/java/com/ll/simpleDb/Article.java
@@ -1,10 +1,8 @@
 package com.ll.simpleDb;
 
-import lombok.Getter;
 
 import java.time.LocalDateTime;
 
-@Getter
 public class Article {
     private long id;
     private LocalDateTime createdDate;
@@ -12,4 +10,28 @@ public class Article {
     private String title;
     private String body;
     private boolean isBlind;
+
+    public long getId() {
+        return id;
+    }
+
+    public LocalDateTime getCreatedDate() {
+        return createdDate;
+    }
+
+    public LocalDateTime getModifiedDate() {
+        return modifiedDate;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public boolean isBlind() {
+        return isBlind;
+    }
 }

--- a/src/test/java/com/ll/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/ll/simpleDb/SimpleDbTest.java
@@ -1,7 +1,8 @@
 package com.ll.simpleDb;
 
-import com.ll.Article;
+
 import com.ll.SimpleDb.SimpleDb;
+import com.ll.SimpleDb.Sql;
 import org.junit.jupiter.api.*;
 
 import java.time.LocalDateTime;


### PR DESCRIPTION
Sql에서 파라미터 바인딩을 할 때 Statement를 쓰는 것처럼 SQL injection을 개발자가 하나하나 신경 쓰는 방식으로 넣었습니다.
입력이 끊어서 들어오니 그 때 그 때 set을 이용할 수 없다고 생각해서 그랬습니다.
그 때 동시성 문제에 대한 방법이 떠오르질 않아서 다른 분 레포를 봤었는데, List에 한 번에 Object 타입으로 받아놓고 진짜 실행할 때 ?에 차례차례 setObject로 등록하면 된다는 걸 알았습니다. 
처음에는 이렇게 짰다는 걸 히스토리로 남기기 위해 이렇게 제출합니다.